### PR TITLE
Automating custom html.js creation as part of install:arduino-base cmd.

### DIFF
--- a/scripts/install-arduino-base.js
+++ b/scripts/install-arduino-base.js
@@ -17,3 +17,14 @@ execSync('yarn add react-scrollable-list');
 
 // Copy wrapper page into Gatsby pages directory
 execSync('cp src/Arduino/arduino-base/ReactSerial/examples/gatsby/gatsby-wrapper-page.js src/pages/arduino.js');
+
+// Customize Gatsby's default html.js to create ipcRenderer reference.
+if (!fs.existsSync('src/html.js')) {
+  // Build site to generate .cache directory
+  if (!fs.existsSync('.cache')) {
+    execSync('yarn build');
+  }
+
+  // Inject script into customized html.js
+  execSync('sed "s^</body>^  <script dangerouslySetInnerHTML={{ __html: \\`if (typeof require !== \'undefined\') window.ipcRef = require(\'electron\').ipcRenderer;\\` }} />\\\n</body>^" .cache/default-html.js > src/html.js');
+}


### PR DESCRIPTION
This automates the final manual step described [here](https://www.gatsbyjs.com/docs/custom-html/). 

To test, follow the README setup in `app-template`, then run `yarn install:arduino-base`. 
Point Stele at `http://localhost:3000/arduino` and test Arduino communication. 

@brandonwkipp what do you think about this change? I'm open to this being a bad idea, in the sense that it may be good for future developers to perform this step manually as a way to understand how React and Stele communicate.