### PR TITLE
EXTCH-6: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--- Your description goes here -->
+
+
+### Preparation checklist
+
+* [ ] Merge `main` into your branch and resolve resulting conflicts
+* [ ] Select one or multiple reviewers who are well suited to discuss your changes
+* [ ] Write a new programmatic test, if warranted
+* [ ] Edit or create the documentation necessary for others to make use of your changes
+
+### Writing a helpful description
+
+* [ ] Link to the specific user-story being addressed, and describe how you've addressed it
+* [ ] Describe how your changes should be tested
+* [ ] Link to specific files, line-numbers, and decisions you would like feedback on
+* [ ] Bonus: Include screenshots or screen-captures to describe any visual changes


### PR DESCRIPTION
This PR adds a [copy of the PR template from smm.org repo](https://github.com/scimusmn/smm.org/blob/main/.github/pull_request_template.md). It [should be helpful](https://smm.atlassian.net/browse/EXTCH-6) for directing folks making PRs in the future (sadly, it will not show up on this PR).